### PR TITLE
Made it work on ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ docker build --tag buccaneer/lc-query-server ./lc-query-server
 docker run -p 8082:8082 --name lc-query-server-container --link lc-mongodb-container buccaneer/lc-query-server
 ```
 
+##### Linked Connections Server.js
+
+```bash
+docker build --tag buccaneer/lc-server ./lc-query-server
+```
+```bash
+docker run -p 8084:8084 --name lc-server-container --link lc-mongodb-container buccaneer/lc-server
+```
+
 ##### NGINX Cache
 __!!__ First replace the IP address in lc-cache/conf/nginx.conf on line 49 (proxy pass) with that of your docker machine or localhost.
 

--- a/README.md
+++ b/README.md
@@ -14,22 +14,24 @@ docker run -p 28001:27017 --name lc-mongodb-container buccaneer/lc-mongodb
 ```
 Import the connections into the database.  Make sure to replace the --host with that of your docker machine or localhost if native.
 ```bash
-gunzip -c belgianrailconnectionsOct2015.mongojsonstream.gz | mongoimport --db lc --collection connections --host 192.168.99.100 --port 28001
+gunzip -c belgianrailconnectionsOct2015.mongojsonstream.gz | mongoimport --db lc --collection connections --port 28001
 ```
 Ensure there is an index on departureTime. Make sure to replace the host with that of your docker machine or localhost if native.
 ```bash
-mongo 192.168.99.100:28001
+mongo --port 28001
 ```
+
 ```bash
 db.connections.ensureIndex({departureTime:1});
 ```
+
 ##### Query Server
 Build the query server image and run it in a container.
 ```bash
 docker build --tag buccaneer/lc-query-server ./lc-query-server
 ```
 ```bash
-docker run -p 32777:8082 --name lc-query-server-container --link lc-mongodb-container buccaneer/lc-query-server
+docker run -p 8082:8082 --name lc-query-server-container --link lc-mongodb-container buccaneer/lc-query-server
 ```
 
 ##### NGINX Cache

--- a/lc-cache/conf/nginx.conf
+++ b/lc-cache/conf/nginx.conf
@@ -45,11 +45,11 @@ http {
         location / {
             #root   html;
             #index  index.html index.htm;
-			proxy_cache my_cache;
-			proxy_pass http://192.168.99.100:32777;
-			proxy_cache_valid 200 60m;
-			add_header X-Proxy-Cache $upstream_cache_status;
-                        expires 30d;
+            proxy_cache my_cache;
+            proxy_pass http://lc-server-container:8084;
+            proxy_cache_valid 200 1m;
+            add_header X-Proxy-Cache $upstream_cache_status;
+            expires 1m;
         }
 
         #error_page  404              /404.html;

--- a/lc-query-server/Dockerfile
+++ b/lc-query-server/Dockerfile
@@ -6,10 +6,8 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-COPY ./query-server/package.json /usr/src/app/
-RUN npm install
-
 COPY ./query-server /usr/src/app
 COPY config.json /usr/src/app/
-
+RUN npm install
+CMD npm start
 EXPOSE 8082

--- a/lc-query-server/config.json
+++ b/lc-query-server/config.json
@@ -1,7 +1,7 @@
 {
   "source" : {
     "type" : "mongodb",
-    "string" : "mongodb://192.168.99.100:28001/lc",
+    "string" : "mongodb://lc-mongodb-container:27017/lc",
     "collections" : {
       "connections" : "connections"
     }

--- a/lc-server/Dockerfile
+++ b/lc-server/Dockerfile
@@ -6,10 +6,8 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-COPY ./query-server/package.json /usr/src/app/
-RUN npm install
-
-COPY ./query-server /usr/src/app
+COPY ./server /usr/src/app
 COPY config.json /usr/src/app/
-
-EXPOSE 8084
+RUN npm install
+CMD node bin/server.js -c config.json
+EXPOSE 8082

--- a/lc-server/config.json
+++ b/lc-server/config.json
@@ -1,15 +1,15 @@
 {
   "source" : {
     "type" : "mongodb",
-    "string" : "mongodb://192.168.99.100:28001/lc",
+    "string" : "mongodb://lc-mongodb-container:27017/lc",
     "collections" : {
       "connections" : "connections"
     }
   },
   "port" : 8084,
   "proxy" : {
-    "port" : 80,
-    "hostname" : "",
+    "port" : 8084,
+    "hostname" : "localhost",
     "protocol" : "http"
   }
 }


### PR DESCRIPTION
Took a while for me to figure out how docker works and understand how to make these scripts work on ubuntu. Here are my findings:
- ubuntu docker works straight on the kernel instead of in a virtual machine (windows) and there's no need to refer to another host with a custom IP here
- the `-p` flag on `docker run` is built as follows: `target_port:exposed_port`. Only when you give this `-p` flag, you will be able to access it from out of your docker container. However, this flag does not influence a linked container. E.g., when you run a container with `-p 8080:8081`, on you ubuntu machine you will be able to reach at http://localhost:8080 whatever is exposed on the docker at port 8081. If you however want to link 2 docker containers together, you'll still need to use port 8081 in the target container.
- the `--link` flag can also configure an alias as follows: `--link lc-mongodb-container:mongo`. This will make available a mongo host (at least when you're **on docker-engine 1.11**) in the target container. If there's no alias, the hostname available will be the full name `lc-mongodb-container` (this is what I still use ↓). An interesting something to do is to check the environment of your last created docker container as follows: `docker run lc-mongodb-container env`. This will show you the ports, hostnames and ip addresses of any linked container that is available. We could use these variables in our scripts instead of hardcoding them.
- When I hit `docker run` earlier on a Dockerfile with `FROM node:5`, it exited immediately. This was quite normal in fact, as the Dockerfile did not contain a command to run (maybe the `FROM node:5-onbuild` does something automatically?). When adding `CMD npm start` to the Dockerfile, it starts as expected though.

Some TODOs before we should merge this PR:
- [ ] We should make the extra IP address instead of localhost configurable
- [ ] We should work with docker 1.11 only :) Upgrade your systems!

I also made the Dockerfile of lc-query-server-container a bit shorter by copying the package.json only once.

@Buccaneer @sballieu 
